### PR TITLE
feat: implement proper configuration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +102,8 @@ name = "bot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "config",
+ "serde",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -144,6 +157,19 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "config"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+dependencies = [
+ "async-trait",
+ "pathdiff",
+ "serde",
+ "toml",
+ "winnow",
 ]
 
 [[package]]
@@ -611,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1159,40 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1537,6 +1612,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
+config = { version = "0.15.11", default-features = false, features = ["async", "toml"] }
+serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,54 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Configuration {
+    /// The bot's discord token.
+    pub token: String,
+}
+
+impl Configuration {
+    /// Read the configuration from the specified location.
+    ///
+    /// Each path is a layer: values set in later entries override the values set by earlier ones.
+    pub fn read<'a>(locations: impl IntoIterator<Item = &'a Path>) -> anyhow::Result<Self> {
+        let mut settings = config::Config::builder();
+        for location in locations {
+            settings = settings.add_source(config::File::from(location).required(false));
+        }
+
+        let config = settings
+            .add_source(config::Environment::with_prefix("BOT"))
+            .build()
+            .context("failed to build config")?;
+
+        config
+            .try_deserialize()
+            .context("failed to deserialize config")
+    }
+
+    /// Reads the configuration from the locations specified in the environment variable. The paths
+    /// in `default` are used if the variable is not set.
+    ///
+    /// See also: [Configuration::read].
+    pub fn read_with_env<'a>(
+        env_var: &str,
+        default: impl IntoIterator<Item = &'a Path>,
+    ) -> anyhow::Result<Self> {
+        match env::var(env_var) {
+            Ok(paths) => {
+                let paths = paths
+                    .split(',')
+                    .map(|p| PathBuf::from(p))
+                    .collect::<Vec<_>>();
+                Self::read(paths.iter().map(|p| p.as_path()))
+            }
+            Err(_) => Self::read(default),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
-use std::{env, sync::Arc};
+mod config;
+
+use std::{path::Path, sync::Arc};
 use tracing::{info, instrument, level_filters::LevelFilter};
 use tracing_subscriber::{EnvFilter, filter::Directive};
 use twilight_cache_inmemory::{DefaultInMemoryCache, ResourceType};
@@ -15,11 +17,11 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let token = env::var("DISCORD_TOKEN")?;
+    let config = config::Configuration::read_with_env("CONFIG_PATH", [Path::new("bot.toml")])?;
 
-    let mut shard = Shard::new(ShardId::ONE, token.clone(), Intents::all());
+    let mut shard = Shard::new(ShardId::ONE, config.token.clone(), Intents::all());
 
-    let http = Arc::new(HttpClient::builder().token(token).build());
+    let http = Arc::new(HttpClient::builder().token(config.token).build());
 
     let cache = DefaultInMemoryCache::builder()
         .resource_types(ResourceType::MESSAGE)


### PR DESCRIPTION
The #7 PR was getting messy really quickly in terms of configuration. This PR implements a proper way to configure the bot.

By default the bot will read from `bot.toml`. This path can be changed with the `CONFIG_PATH` environment variable. Use comma separators in this variable for multiple config paths, which will be read in the order you specify.
Finally, environment variables with the prefix BOT_ will also be read into the configuration and overwrite anything you specify in the config files.

Ie: to specify the bot token you can set the `BOT_TOKEN` environment variable or set `token` in `bot.toml`.