### PR TITLE
feat(anti-hoisting): add anti-hoisting functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "base64",
  "config",
  "image",
+ "regex",
  "reqwest",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.22.1"
 config = { version = "0.15.11", default-features = false, features = ["async", "toml"] }
 image = "0.25.6"
+regex = "1.11.1"
 reqwest = "0.12.15"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.0", features = ["full"] }

--- a/src/anti_hoisting.rs
+++ b/src/anti_hoisting.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+
+use regex::Regex;
+use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tracing::{debug, info, warn};
+use twilight_gateway::Event;
+use twilight_http::Client;
+use twilight_model::{gateway::{payload::incoming::MemberUpdate, Intents}, guild::Member, id::{marker::RoleMarker, Id}};
+
+// https://discord.com/developers/docs/resources/user
+fn default_max_nickname_length() -> u32 {
+    32
+}
+
+fn default_min_nickname_length() -> u32 {
+    1
+}
+
+use serde::de::{Deserialize, Deserializer, Error};
+fn deserialize_regex<'de, D>(deserializer: D) -> Result<Regex, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    Regex::new(&s).map_err(Error::custom)
+}
+
+#[derive(Debug)]
+pub struct Configuration {
+    /// Whether anti-hoisting is enabled
+    pub enabled: bool,
+    /// The maximum length of a nickname
+    /// defaults to 32
+    /// ONLY CHANGE THIS IF YOU KNOW WHAT YOU ARE DOING
+    pub max_nickname_length: u32,
+    /// The minimum length of a nickname
+    /// defaults to 1
+    /// ONLY CHANGE THIS IF YOU KNOW WHAT YOU ARE DOING
+    pub min_nickname_length: u32,
+    /// Name format that triggers anti-hoisting
+    /// e.g. ^[A-Za-z]{2,}
+    pub trigger: Regex, // TODO only single letters are allowed
+    /// The output message to send to the user
+    /// Must contain the literal `${nickname}`
+    /// Example: `Box<${nickname}>`
+    pub output: String,
+    /// Roles that are able to bypass anti-hoisting
+    pub ignore_roles: Vec<Id<RoleMarker>>
+}
+
+/// Deserialize Configuration
+/// This is needed to provide config error handling at the time of deserialization
+impl<'de> Deserialize<'de> for Configuration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de> {
+
+        #[derive(serde::Deserialize)]
+        struct RawConfiguration {
+            #[serde(default)]
+            enabled: bool,
+            #[serde(default = "default_max_nickname_length")]
+            max_nickname_length: u32,
+            #[serde(default = "default_min_nickname_length")]
+            min_nickname_length: u32,
+            #[serde(deserialize_with = "deserialize_regex")]
+            trigger: Regex,
+            output: String,
+            #[serde(default)]
+            ignore_roles: Vec<Id<RoleMarker>>
+        }
+
+        let RawConfiguration {
+            enabled,
+            max_nickname_length,
+            min_nickname_length,
+            trigger,
+            output,
+            ignore_roles
+        } = RawConfiguration::deserialize(deserializer)?;
+
+        let output = output.trim();
+        
+        // invalid if output does not contain ${nickname}
+        if !output.contains(AntiHoisting::NICKNAME_PLACEHOLDER) {
+            return Err(Error::custom("`output` must contain `${nickname}`"));
+        };
+
+        //TODO validation
+
+        Ok(Configuration {
+            enabled,
+            max_nickname_length,
+            min_nickname_length,
+            trigger,
+            output: output.to_owned(),
+            ignore_roles,
+        })
+    }
+}
+
+pub struct AntiHoisting {}
+
+impl AntiHoisting {
+    pub const INTENTS: Intents = Intents::GUILD_MEMBERS;
+    pub const NICKNAME_PLACEHOLDER: &str = "${nickname}";
+
+    /// run the main anti-hoisting logic
+    pub async fn serve(config: Configuration, mut events: Receiver<Arc<Event>>, http: Arc<Client>) {
+        loop {
+            let event = events.recv().await;
+
+            // match events where a member's name is hoisted
+            let hoisted_member = match event.as_deref() {
+                Err(RecvError::Closed) => return,
+                Err(_) => continue,
+                Ok(Event::MemberUpdate(m)) if m.nick.as_ref().map_or(false, |nick| AntiHoisting::is_hoisted(&config.trigger, &nick))  => m,
+                Ok(_) => continue,
+            };
+
+            // skip member with a role that bypasses anti-hoisting
+            if hoisted_member.roles.iter().any(|role| config.ignore_roles.contains(role)) {
+                debug!("Member {:#?} has a role that bypasses anti-hoisting, skipping", hoisted_member.user.name);
+                continue;
+            };
+            
+            // Only nicknames are supported
+            let Some(ref old_nickname) = hoisted_member.nick else {
+                debug!("Member {:#?} has not changed a nickname, skipping", hoisted_member.user.name);
+                continue;
+            };
+
+            let new_nickname = AntiHoisting::transform(&old_nickname, &config.output);
+
+            // the output can produce a nickname longer than max_nickname_length
+            // for now the strategy is to not change the nickname
+            if new_nickname.len() > config.max_nickname_length as usize {
+                continue;
+            }
+
+            let result = Self::change_nickname(&hoisted_member, &new_nickname, &http).await;
+
+            let member= match result {
+                Err(err) => {
+                    // permission errors
+                    warn!("Failed to change nickname: {err}");
+                    continue;
+                },
+                Ok(m) if m.nick.as_ref().map_or(false, |nick| *nick == new_nickname) => m,
+                Ok(_) => continue,
+            };
+
+            info!("Member has tried to hoist with name: {:#?} set new nickname to: {:#?}", hoisted_member.nick, &new_nickname);
+        }
+    }
+
+    async fn change_nickname(hoisted_member: &Box<MemberUpdate>, new_nickname: &str, http: &Arc<Client>) -> anyhow::Result<Member> {
+        Ok(http
+            .update_guild_member(hoisted_member.guild_id, hoisted_member.user.id)
+            .nick(Some(&new_nickname))
+            .await?.model().await?)
+    }   
+
+    fn is_hoisted(trigger: &Regex, nickname: &str) -> bool {
+        trigger.is_match(nickname)
+    }
+
+    fn transform(old_nickname: &str, output: &str) -> String {
+        output.replace(Self::NICKNAME_PLACEHOLDER,old_nickname)
+    }
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use serde::Deserialize;
 
 use crate::ai_channel;
+use crate::anti_hoisting;
 
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
@@ -14,6 +15,8 @@ pub struct Configuration {
     pub token: String,
     #[serde(default, rename = "ai_channel")]
     pub ai_channels: Vec<ai_channel::Configuration>,
+    #[serde(default)]
+    pub anti_hoisting: Option<anti_hoisting::Configuration>,
 }
 
 impl Configuration {


### PR DESCRIPTION
# Considerations

Before merging this, I still need to work on some validation for this feature. Especially since config related errors should rather be notified to the user upon startup and not during event handling (for now). However, it would even be good to wait until we have a proper framework in place that encapsulates this component more.

The current strategy for names longer than the [32 character](https://discord.com/developers/docs/resources/user) limit is to not change the name at all.

This feature requires the [regex crate](https://crates.io/crates/regex) to parse and use regex.

# To Be Done
**Required**
- [x] define config in `bot.toml`
- [x] prevent hoisting by detecting and changing a user's nickname to a defined output
- [ ] improve validation in case of misconfiguration.

**Optional**
- [x] specify regex as trigger
- [x] implement a `ignore_roles` config property to allow hoisting for certain roles
- [ ] write some test cases
- [ ] detect already renamed users on startup
- [ ] make the bot detect and change nicknames with a delay
- [ ] cache the members

Closes #12